### PR TITLE
Properly handle no-break space in subtitles

### DIFF
--- a/src/Subtitles/RTS.cpp
+++ b/src/Subtitles/RTS.cpp
@@ -1793,12 +1793,12 @@ void CRenderedTextSubtitle::ParseString(CSubtitle* sub, CStringW str, STSStyle& 
 
 	str.Replace(L"\\N", L"\n");
 	str.Replace(L"\\n", (sub->m_wrapStyle < 2 || sub->m_wrapStyle == 3) ? L" " : L"\n");
-	str.Replace(L"\\h", L"\x00A0");
+	str.Replace(L"\\h", L"\x00A0"); // no-break space
 
 	for (int i = 0, j = 0, len = str.GetLength(); j <= len; j++) {
 		WCHAR c = str[j];
 
-		if (c != L'\n' && c != L' ' && c != L'\x00A0' && c != 0) {
+		if (c != L'\n' && c != L' ' && c != 0) {
 			continue;
 		}
 
@@ -1814,7 +1814,7 @@ void CRenderedTextSubtitle::ParseString(CSubtitle* sub, CStringW str, STSStyle& 
 				sub->m_words.AddTail(w);
 				m_kstart = m_kend;
 			}
-		} else if (c == L' ' || c == L'\x00A0') {
+		} else if (c == L' ') {
 			if (CWord* w = DNew CText(style, CStringW(c), m_ktype, m_kstart, m_kend, sub->m_scalex, sub->m_scaley, m_renderingCaches)) {
 				sub->m_words.AddTail(w);
 				m_kstart = m_kend;


### PR DESCRIPTION
Fixed https://github.com/Aleksoid1978/MPC-BE/issues/7
Refer https://github.com/clsid2/mpc-hc/commit/96f3a257fdb37250935c5bfed94ec2b0ac3de1fd
Test build: 
[MPC-BE.1.6.2.6909_git2022.02.17-fa05adf39.x64.zip](https://github.com/Aleksoid1978/MPC-BE/files/8102826/MPC-BE.1.6.2.6909_git2022.02.17-fa05adf39.x64.zip)
