### PR TITLE
MatroskaSplitter: Support VVC Matroska demux

### DIFF
--- a/src/ExtLib/MediaInfo/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/src/ExtLib/MediaInfo/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1630,6 +1630,7 @@ void MediaInfo_Config_CodecID_Video_Matroska (InfoMap &Info)
     "V_MPEG4/ISO/AP;MPEG-4 Visual;;Advanced Profile;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEG4/ISO/AVC;AVC;;;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEGH/ISO/HEVC;HEVC\n"
+    "V_MPEGI/ISO/VVC;VVC\n"
     "V_MPEG4/MS/V2;MPEG-4 Visual;MS MPEG-4 v2;MS MPEG-4 v2;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEG4/MS/V3;MPEG-4 Visual;MS MPEG-4 v3;MS MPEG-4 v3;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEG1;MPEG Video;;MPEG 1 or 2 Video;http://ffdshow-tryout.sourceforge.net/\n"

--- a/src/filters/parser/MatroskaSplitter/MatroskaSplitter.cpp
+++ b/src/filters/parser/MatroskaSplitter/MatroskaSplitter.cpp
@@ -598,6 +598,8 @@ HRESULT CMatroskaSplitterFilter::CreateOutputs(IAsyncReader* pAsyncReader)
 						fourcc = FCC('VP90');
 					} else if (CodecID == "V_AV1") {
 						fourcc = FCC('AV01');
+					} else if (CodecID == "V_MPEGI/ISO/VVC") {
+						fourcc = FCC('VVC1');
 					} else if (CodecID == "V_QUICKTIME" && pTE->CodecPrivate.size() >= 8) {
 						if (m_pFile->m_ebml.DocTypeReadVersion == 1) {
 							fourcc = GETU32(pTE->CodecPrivate.data());


### PR DESCRIPTION
This will support Versatile Video Codec demux of Matroska, because the official tag name is V_MPEGI/ISO/VVC from Matroska specification.