### PR TITLE
Use playlist label as window title for URL streams

### DIFF
--- a/src/apps/mplayerc/MainFrm.cpp
+++ b/src/apps/mplayerc/MainFrm.cpp
@@ -12458,6 +12458,10 @@ CString CMainFrame::OpenFile(OpenFileData* pOFD)
 		m_PlaybackInfo.FileName = GetFileName(pOFD->fi);
 	}
 	else if (youtubeUrl.IsEmpty()) {
+		CPlaylistItem pli;
+		if (m_wndPlaylistBar.GetCur(pli) && pli.m_fi.Valid() && pli.m_label.GetLength()) {
+			m_PlaybackInfo.FileName = pli.m_label;
+		}
 		m_PlaybackInfo.bUpdateTitle = true;
 	}
 


### PR DESCRIPTION
For non-YouTube URL streams, m_PlaybackInfo.FileName was left empty, causing the window title and seek bar to display the full raw URL instead of the decoded filename extracted from the URL path.

Now the already-decoded playlist label (derived from the URL path in CPlayerPlaylistBar::AddItem) is used as the display name.

History files are unaffected because m_SessionInfo.Title remains empty for auto-generated labels, preserving the fix for Issue #795.