### PR TITLE
fix: Validate HDMV palette entry count against 8-bit palette limit

### DIFF
--- a/src/Subtitles/HdmvSub.cpp
+++ b/src/Subtitles/HdmvSub.cpp
@@ -426,6 +426,9 @@ void CHdmvSub::ParsePalette(CGolombBuffer* pGBuffer, USHORT nSize)
 
 	ASSERT((nSize - 2) % sizeof(HDMV_PALETTE) == 0);
 	int nNbEntry = (nSize - 2) / sizeof(HDMV_PALETTE);
+	if (nNbEntry > 256) {
+		return;
+	}
 	HDMV_PALETTE* pPalette = (HDMV_PALETTE*)pGBuffer->GetBufferPos();
 
 	SAFE_DELETE_ARRAY(m_CLUT[palette_id].Palette);


### PR DESCRIPTION
## Summary
This change rejects malformed HDMV palette segments containing more than 256 entries.

HDMV subtitle palette entries are addressed by 8-bit palette indices, so accepting more than 256 entries is outside the meaningful range for this format. While the current allocation path sizes the destination buffer from the parsed entry count, bounding the value makes the parser stricter, avoids unnecessary allocation on malformed input, and prevents future code from accidentally assuming the palette size is always within the 8-bit index space.

This is intended as defensive/spec-conformance hardening rather than a demonstrated out-of-bounds write.

## Changes
- `src/Subtitles/HdmvSub.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
