### PR TITLE
fix(subtitles): avoid AVX2 tail overread

### DIFF
--- a/src/Subtitles/Rasterizer.cpp
+++ b/src/Subtitles/Rasterizer.cpp
@@ -1476,7 +1476,7 @@ namespace
 				__m128i d1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(dst));
 				__m128i d2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(dst + 16));
 				__m128i d3 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(dst + 32));
-				__m128i d4 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(dst + 64));
+				__m128i d4 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(dst + 48));
 
 				auto c_r_low = _mm256_castsi256_si128(c_r);
 				auto c_g_low = _mm256_castsi256_si128(c_g);


### PR DESCRIPTION
## Summary
- Fix the AVX2 solid-fill 16-pixel tail path to load the fourth 128-bit chunk from `dst + 48` instead of `dst + 64`.
- This keeps the tail load aligned with the following store offsets and avoids reading past the 64-byte tail block.

## Verification
- Built `src\Subtitles\Subtitles.vcxproj` with `Configuration=Release`, `Platform=x64`.
- No crash with new build.

## Notes
- This was found while testing a PGS/SUP subtitle generated by ass2bdnxml v1.10 that can crash MPC-BE 1.8.9 x64 around 01:44:08 when seeking nearby.
- video & sup file which can reproduce the problem: https://drive.google.com/file/d/19u8xhIOFEmdd_382MRQ_b-_uekDlEIGl/view?usp=sharing, https://drive.google.com/file/d/1tjqW1GbTWfRQnMAbSHJpQBJNNcD5npcR/view?usp=sharing