### PR TITLE
Fix two MPCVideoDec.ax crashes on filter graph/process teardown

### DIFF
--- a/src/filters/transform/BaseVideoFilter/BaseVideoFilter.cpp
+++ b/src/filters/transform/BaseVideoFilter/BaseVideoFilter.cpp
@@ -494,7 +494,16 @@ CBaseVideoInputPin::CBaseVideoInputPin(LPCWSTR pObjectName, CBaseVideoFilter* pF
 
 CBaseVideoInputPin::~CBaseVideoInputPin()
 {
-	delete m_pAllocator;
+	// m_pAllocator is a COM object (CMemAllocator/CUnknown) that may still be
+	// held by other owners (the base CBaseInputPin::m_pAllocator slot set up
+	// in GetAllocator()'s caller, and potentially the connected output pin).
+	// Releasing instead of deleting avoids freeing it out from under a
+	// reference another pin still holds, which previously caused a
+	// use-after-free crash in CBaseAllocator::Decommit() during filter graph
+	// teardown.
+	if (m_pAllocator) {
+		m_pAllocator->Release();
+	}
 }
 
 STDMETHODIMP CBaseVideoInputPin::GetAllocator(IMemAllocator** ppAllocator)

--- a/src/filters/transform/MPCVideoDec/DxgiUtils.h
+++ b/src/filters/transform/MPCVideoDec/DxgiUtils.h
@@ -32,6 +32,15 @@ public:
 		return *m_pInstance;
 	}
 
+	// Explicitly release the singleton while dxgi.dll is still guaranteed to be
+	// loaded (e.g. from the last filter instance's destructor). Without this,
+	// the unique_ptr's static destructor runs during process shutdown, after
+	// dxgi.dll may already have unloaded/torn down, crashing on exit.
+	inline static void ReleaseInstance()
+	{
+		m_pInstance.reset();
+	}
+
 	IDXGIFactory1* GetFactory() const;
 
 protected:

--- a/src/filters/transform/MPCVideoDec/MPCVideoDec.cpp
+++ b/src/filters/transform/MPCVideoDec/MPCVideoDec.cpp
@@ -1261,6 +1261,12 @@ CMPCVideoDecFilter::~CMPCVideoDecFilter()
 {
 	Cleanup();
 	m_pD3D11Decoder.reset();
+
+	// Release the process-wide DXGI factory singleton here, while dxgi.dll is
+	// still guaranteed to be loaded. Leaving it to its static destructor means
+	// it can run during DLL_PROCESS_DETACH, after dxgi.dll's own resources may
+	// already be torn down, which crashes on process exit.
+	CDXGIFactory1::ReleaseInstance();
 }
 
 void CMPCVideoDecFilter::DetectVideoCard(HWND hWnd)


### PR DESCRIPTION
## Summary

Two crashes in MPCVideoDec.ax (D3D11 hardware decoding path) found while
debugging TVTest + BonDriver_dantto4k crashing on exit while playing live
BS 4K/8K HEVC. Both are reproducible independent of resolution, but only
under live streaming graph teardown (not reproduced with file playback in
mpc-be64.exe).

- **Filter graph teardown crash** (`CBaseAllocator::Decommit` →
  `CBaseInputPin::BreakConnect`): `CBaseVideoInputPin::~CBaseVideoInputPin()`
  called `delete` on a COM-refcounted allocator that other owners (the base
  `CBaseInputPin::m_pAllocator` slot, potentially the connected output pin)
  could still be referencing, causing a use-after-free. Fixed by calling
  `Release()` instead.
- **Process exit crash** (`DLL_PROCESS_DETACH` → static dtor →
  `CComObject<CDXGIFactory>::~CComObject`): `CDXGIFactory1`'s singleton was
  released by its implicit static destructor during process shutdown,
  potentially after dxgi.dll's own resources were already torn down. Added
  an explicit `ReleaseInstance()` called from the filter's destructor.

## Test plan

- [x] Reproduced the original crash via WinDbg/cdb analysis of crash dumps
      across MPC-BE 1.8.8.0 (2021 build) and 1.8.9.0 (Dec 2025 build) — same
      crash site in both.
- [x] Confirmed crash reproduces live with TVTest + BonDriver_dantto4k on a
      pre-fix build (4K and 8K channels, mid-playback graph teardown).
- [x] Confirmed crash does not reproduce with the fix applied, same
      conditions (4K and 8K, multiple repeated runs).
- [x] Confirmed no regression playing back 4K/8K HEVC files directly in
      mpc-be64.exe with D3D11 decoding (verified via the decoder's Status
      panel: `Output format: D3D11 (HEVC 10-bit)`).