### PR TITLE
Fix MPCVideoDec dangling-pointer crash on resolution-changing channel switch (D3D11/DXVA2 HEVC)

### DIFF
--- a/src/filters/transform/MPCVideoDec/MPCVideoDec.cpp
+++ b/src/filters/transform/MPCVideoDec/MPCVideoDec.cpp
@@ -3618,12 +3618,33 @@ HRESULT CMPCVideoDecFilter::FillAVPacket(const BYTE *buffer, int buflen)
 		size = (buflen + AV_INPUT_BUFFER_PADDING_SIZE) + (buflen + AV_INPUT_BUFFER_PADDING_SIZE) / 16 + 32;
 	}
 
+	// The DXVA2/D3D11 hwaccel path (e.g. dxva2_hevc_decode_slice) keeps a raw
+	// pointer into the packet data alive past this call, from decode_slice()
+	// until the frame's end_frame()/GPU submission completes, instead of
+	// copying or refcounting it. buffer here points into m_pFFBuffer, a single
+	// shared buffer that ParseInternal() reuses (and may av_fast_realloc to a
+	// new address) on every subsequent call. If that reuse happens before a
+	// prior frame's GPU submission finishes, the hwaccel reads through a
+	// dangling/overwritten pointer - observed as a memcpy access violation in
+	// ff_dxva2_commit_buffer, most often when switching to a higher-resolution
+	// (e.g. 8K) channel adds enough extra latency for the reuse to win the race.
+	// Force a real copy on the hwaccel path so each packet owns independent
+	// memory; software decode can keep aliasing buffer since avcodec_send_packet
+	// there doesn't retain it past the call.
+	const bool bForceOwnBufferForHwaccel = (size <= buflen) && (UseDXVA2() || UseD3D11());
+	if (bForceOwnBufferForHwaccel) {
+		size = buflen + AV_INPUT_BUFFER_PADDING_SIZE;
+	}
+
 	if (size > buflen) {
 		if (av_new_packet(m_pPacket, size) < 0) {
 			return E_OUTOFMEMORY;
 		}
 		memcpy(m_pPacket->data, buffer, buflen);
 		memset(m_pPacket->data + buflen, 0, size - buflen);
+		if (bForceOwnBufferForHwaccel) {
+			m_pPacket->size = buflen;
+		}
 	} else {
 		m_pPacket->data = const_cast<uint8_t*>(buffer);
 		m_pPacket->size = buflen;


### PR DESCRIPTION
## Problem

Switching a live channel from a lower resolution to a higher one (e.g. 4K to
8K) while using D3D11 (or DXVA2) hardware decoding of HEVC crashes nearly
every time, with an access violation inside `ff_dxva2_commit_buffer`'s
`memcpy`. Reproduced with both MPC Video Renderer and EVR as the downstream
renderer, which rules out either renderer and points at MPCVideoDec.ax
itself. Same-resolution switches (4K to 4K) never crash.

## Root cause

`CMPCVideoDecFilter::FillAVPacket()` in `MPCVideoDec.cpp` pointed
`AVPacket->data` directly at `m_pFFBuffer` instead of copying it, for any
codec that doesn't need PRORES's padded-buffer path. `m_pFFBuffer` is a
single buffer that `ParseInternal()` reuses (and may reallocate via
`av_fast_realloc`) on every subsequent call.

FFmpeg's DXVA2/D3D11 HEVC hwaccel keeps that raw pointer alive well past the
`FillAVPacket()`/`avcodec_send_packet()` call: `dxva2_hevc_decode_slice()`
(`libavcodec/dxva2_hevc.c`) stores it as `ctx_pic->bitstream`, and it isn't
actually read until the frame's `end_frame()`/GPU submission via
`ff_dxva2_commit_buffer()`'s `memcpy(dxva_data, data, size)` in
`libavcodec/dxva2.c` — i.e. asynchronously, after `decode_slice()` already
returned. If `m_pFFBuffer` gets reused or reallocated for a later packet
before that GPU submission completes, the hwaccel ends up reading through a
dangling or overwritten pointer.

A resolution change adds just enough extra latency
(`CD3D11Decoder::ReInitD3D11Decoder()` tearing down and rebuilding the
decoder/surface pool) for this race to be won reliably. Same-resolution
switches never hit that reinit path, so the race window stays narrow enough
to not normally reproduce — but the underlying bug is not actually specific
to resolution changes.

## Fix

Force `FillAVPacket()` to make a real `av_new_packet` copy whenever the
filter is using DXVA2 or D3D11 hardware decoding, instead of aliasing the
shared `buffer` pointer, so each packet owns independent memory regardless
of how/when `m_pFFBuffer` gets reused. The existing PRORES oversized-buffer
copy-path behavior (`pkt->size` left as the padded `size`) is unchanged.

## Testing

Repeated 4K -> 8K -> 4K -> 8K ... channel switching under D3D11 hardware
decoding (HEVC), with both MPC Video Renderer and EVR — previously crashed
on almost every switch to the higher resolution, no crashes after this fix
across many repeated switches.