### PR TITLE
Avoid EC_DISPLAY_CHANGED for output-format-only renderer notifications in MPCVideoDec

### DIFF
--- a/src/filters/transform/MPCVideoDec/MPCVideoDec.cpp
+++ b/src/filters/transform/MPCVideoDec/MPCVideoDec.cpp
@@ -4122,10 +4122,38 @@ HRESULT CMPCVideoDecFilter::ChangeOutputMediaFormat(int nType)
 
 		IPin* pPin = m_pOutput->GetConnected();
 		if (IsVideoRenderer(GetFilterFromPin(pPin))) {
-			hr = NotifyEvent(EC_DISPLAY_CHANGED, (LONG_PTR)pPin, 0);
-			if (S_OK != hr) {
-				hr = E_FAIL;
+			// EC_DISPLAY_CHANGED is meant for a presenter/renderer to announce that
+			// *it* just reset its D3D device (see SyncRenderer.cpp's OnResetDevice()
+			// and EVRAllocatorPresenter.cpp, both literally quoting MS docs: "Presenter
+			// should send this message" after ResetDevice()). Using it here to mean
+			// "the decoder's output format changed" is a different thing entirely, and
+			// quartz.dll's default filter graph manager reacts to it by automatically
+			// Stop()-ing (and restarting) the whole graph on its own worker thread -
+			// confirmed via logging that this is exactly what was forcing
+			// CompleteConnect(PINDIR_OUTPUT)/PostConnect() to run again ~100ms later,
+			// recreating the D3D11 device a 2nd/3rd time within under a second at
+			// startup. That device churn is the root cause of a separate bug (D3D11
+			// startup/renderer-switch sometimes showing no video - GPU resource cleanup
+			// from rapid device recreation can leave a freshly (re)committed allocator's
+			// buffer creation failing for several seconds). Send the new media type the
+			// same in-place way ReconnectOutput() already does for resolution changes -
+			// CD3D11Decoder::DeliverFrame() already checks m_bSendMediaType and carries
+			// it on the next delivered sample - instead of forcing a connection-level
+			// reconnect via EC_DISPLAY_CHANGED.
+			int nNumber;
+			VFormatDesc* pFormats;
+			GetOutputFormats(nNumber, &pFormats);
+			bool bSent = false;
+			for (int i = 0; i < nNumber * 2; i++) {
+				CMediaType mt;
+				if (SUCCEEDED(GetMediaType(i, &mt)) && pPin->QueryAccept(&mt) == S_OK) {
+					m_pOutput->SetMediaType(&mt);
+					m_bSendMediaType = true;
+					bSent = true;
+					break;
+				}
 			}
+			hr = bSent ? S_OK : E_FAIL;
 		} else {
 			int nNumber;
 			VFormatDesc* pFormats;


### PR DESCRIPTION
## Problem

With D3D11 hardware decoding selected, a connected video renderer (in my
case the MPC Video Renderer, but the underlying mechanism is
renderer-agnostic) can sometimes show no video at all - at TVTest's startup
auto-tune, or right after switching the renderer setting while a stream is
playing. Manually toggling playback off/on (forcing a fresh `avcodec_open2()`)
"fixes" it.

## Root cause

`CMPCVideoDecFilter::ChangeOutputMediaFormat()`'s renderer branch calls
`NotifyEvent(EC_DISPLAY_CHANGED, (LONG_PTR)pPin, 0)` to tell a connected
video renderer that the decoder's output media type changed.

`EC_DISPLAY_CHANGED` is meant for a *presenter* to announce that *it* just
reset its own D3D device - see `SyncRenderer.cpp`'s `OnResetDevice()` and
`EVRAllocatorPresenter.cpp`, both of which send this event right after
`ResetDevice()`, with a comment citing Microsoft's documentation
("Presenter should send this message").

quartz.dll's default filter graph manager reacts to `EC_DISPLAY_CHANGED` by
automatically `Stop()`-ing (and restarting) the whole graph on its own
worker thread (`CFGControl::WorkerDisplayChanged` -> `CFilterGraph::Stop()`).
Since `ChangeOutputMediaFormat(2)` is reached the first time a D3D11 decode
session discovers its real surface format - i.e. during completely normal
first-time playback, not only on a deliberate resolution change - this
fires on every channel tune, forcing the output pin through
`CompleteConnect()`/`CD3D11Decoder::PostConnect()` again and recreating the
D3D11 device a 2nd (sometimes 3rd) time within under a second of each
other. The resulting GPU resource churn can leave a freshly recreated
allocator's buffer creation failing for several seconds
(`CD3D11SurfaceAllocator::Commit()` returning `E_FAIL`), which has no
recovery path and leaves decode permanently stuck producing no frames.

Confirmed directly via logging: `NotifyEvent(EC_DISPLAY_CHANGED, ...)`
returning, and the *second* `CompleteConnect(PINDIR_OUTPUT)` firing, were
consistently ~100ms apart across multiple repro runs. Also confirmed this
isn't 4K/8K-specific - the same multi-`CompleteConnect()` churn happens with
regular 2K H.264 content too, it just doesn't reliably lose the GPU-resource
race there since the surfaces involved are much smaller.

## Fix

Send the new media type the same in-place way `ReconnectOutput()` already
does for resolution changes, instead of `EC_DISPLAY_CHANGED`: find a media
type the connected pin's `QueryAccept()` accepts, call
`m_pOutput->SetMediaType(&mt)`, and set `m_bSendMediaType = true` so
`CD3D11Decoder::DeliverFrame()` carries it on the next delivered sample via
`IMediaSample::SetMediaType()` - no connection-level reconnect, no
`EC_DISPLAY_CHANGED`, no extra D3D11 device churn.

## Testing

Repeated TVTest startup auto-tune and live switching between MPC Video
Renderer and EVR - both reliably showed no video before this fix, both work
immediately after.