### PR TITLE
Fix DWM frame glitches during fullscreen

### DIFF
--- a/src/apps/mplayerc/MainFrm.cpp
+++ b/src/apps/mplayerc/MainFrm.cpp
@@ -11096,6 +11096,17 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
 
 	m_bFullScreen = !m_bFullScreen;
 
+	// Keep the main HWND logically visible so the normal MFC/child layout runs
+	// during the fullscreen resize, but temporarily remove it from DWM
+	// presentation while its frame and geometry are being rewritten.  Cloaking
+	// is Windows 8+, so Windows 7 and earlier retain the original code path.
+	bool bCloakedForFullscreenTransition = false;
+	if (SysVersion::IsWin8orLater() && IsWindowVisible()) {
+		const BOOL bCloak = TRUE;
+		bCloakedForFullscreenTransition = SUCCEEDED(DwmSetWindowAttribute(
+			m_hWnd, DWMWA_CLOAK, &bCloak, sizeof(bCloak)));
+	}
+
 	ModifyStyle(dwRemove, dwAdd, SWP_NOZORDER);
 
 	static bool bChangeMonitor = false;
@@ -11208,6 +11219,17 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
 
 	m_bFullScreenChangingMode = false;
 	MoveVideoWindow();
+
+	// Reveal only after the final top-level and video-child geometry has been
+	// processed. Wait for the compositor to reach the transition's final
+	// presentation point first; unlike a forced RedrawWindow this does not
+	// synchronously repaint a stale pre-WM_SIZE child surface.
+	if (bCloakedForFullscreenTransition) {
+		DwmFlush();
+
+		const BOOL bCloak = FALSE;
+		DwmSetWindowAttribute(m_hWnd, DWMWA_CLOAK, &bCloak, sizeof(bCloak));
+	}
 
 	if (bChangeMonitor && (!m_bToggleShader || !m_bToggleShaderScreenSpace)) { // Enabled shader ...
 		SetShaders();


### PR DESCRIPTION
## Summary

Fixes fullscreen transition composition artifacts by temporarily cloaking the
main window while MPC-BE performs its existing fullscreen style/layout
transition, then waiting for the compositor to reach the completed presentation
state before revealing it again.

## Problem

On the affected Windows 11 system, switching between windowed and fullscreen
mode can expose intermediate window states.

Depending on the playback state, this can appear as:

- corrupted/non-final window frame contents;
- previous windowed contents appearing temporarily in the upper-left portion
  of the fullscreen window.

The issue is reproducible not only during video playback, but also with
audio-only media and with no media loaded.

## Investigation

Several smaller approaches were tested while isolating the problem.

Simply performing the style and geometry changes atomically was insufficient.

Temporarily hiding the main HWND prevented the original frame corruption, but
introduced another issue. Instrumentation showed that during fullscreen entry
the main window could already be at its final fullscreen dimensions while the
child view still retained its previous windowed dimensions until the subsequent
layout/WM_SIZE processing completed.

This produced the transient upper-left content.

Using `SW_HIDE` is therefore unsuitable because it changes the logical
visibility of the window and interferes with the normal child/layout path.

## Fix

On Windows 8 and later:

1. Cloak the main HWND before MPC-BE's existing fullscreen transition.
2. Leave the existing fullscreen style, window geometry, and child-layout logic
   unchanged.
3. Allow the normal `MoveVideoWindow()` / layout processing to complete.
4. Call `DwmFlush()` while the HWND is still cloaked so pending compositor
   updates reach their presentation point.
5. Remove the cloak.

This keeps the window logically visible throughout the transition, allowing
normal MFC and child-window layout processing to run, while preventing DWM from
presenting the intermediate state.

Windows 7 continues through MPC-BE's original path unchanged.

## Scope

The patch intentionally does not introduce:

- a temporary covering window;
- `WS_POPUP`;
- `SW_HIDE` / `SW_SHOW`;
- changes to MPC-BE's fullscreen style model;
- forced `RedrawWindow()` calls;
- DWM transition-policy changes;
- renderer-specific resize handling;
- tray restore changes.

Only the fullscreen transition composition is affected.

## Testing

Tested on Windows 11 x64 in all of these states:

- video playback;
- audio-only playback;
- no media loaded;
- repeated fullscreen/windowed toggling.

The corrupted frame and upper-left intermediate-content artifacts are no longer
visible in these cases, and window activation/focus remains functional.

## Before

https://github.com/user-attachments/assets/21312cef-56e6-4c6d-a325-b947021971a5

## After

https://github.com/user-attachments/assets/d0b2c86e-8733-4d48-95cb-047707e4863c