### PR TITLE
Work around VS 2026 LTCG ICE in MediaInfo File_Mpeg4_Elements

### DIFF
--- a/src/ExtLib/MediaInfo/MediaInfo.vcxproj
+++ b/src/ExtLib/MediaInfo/MediaInfo.vcxproj
@@ -449,7 +449,12 @@
     <ClCompile Include="MediaInfo\Multiple\File_Mk.cpp" />
     <ClCompile Include="MediaInfo\Multiple\File_Mpeg4.cpp" />
     <ClCompile Include="MediaInfo\Multiple\File_Mpeg4_Descriptors.cpp" />
-    <ClCompile Include="MediaInfo\Multiple\File_Mpeg4_Elements.cpp" />
+    <ClCompile Include="MediaInfo\Multiple\File_Mpeg4_Elements.cpp">
+      <!-- VS 2026 18.8.x can ICE in the LTCG backend for File_Mpeg4::Data_Parse.
+           Keep normal /O2 file-level optimization, but emit native code for this TU
+           instead of deferring it to the final /LTCG pass. -->
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+    </ClCompile>
     <ClCompile Include="MediaInfo\Multiple\File_Mpeg4_TimeCode.cpp" />
     <ClCompile Include="MediaInfo\Multiple\File_MpegPs.cpp" />
     <ClCompile Include="MediaInfo\Multiple\File_MpegTs.cpp" />


### PR DESCRIPTION
## Summary

Works around an MSVC internal compiler error when building MPC-BE Release x64
with Visual Studio 2026 Build Tools 18.8.2.

## Failure

During the final optimized build/code-generation stage, MSVC terminates with:

    File_Mpeg4_Elements.cpp(1596): fatal error C1001: Internal compiler error
    (compiler file '...\Compiler\Utc\src\p2\main.cpp', line 262)

The failure occurs while processing MediaInfo's:

    MediaInfo\Multiple\File_Mpeg4_Elements.cpp

## Workaround

Disable WholeProgramOptimization only for this translation unit:

    <WholeProgramOptimization>false</WholeProgramOptimization>

The rest of MediaInfo and MPC-BE continue using their existing Release
optimization/LTCG configuration.

This avoids disabling LTCG globally and limits the workaround to the source
file that triggers the MSVC optimizer failure.

## Environment

- Visual Studio 2026 Build Tools 18.8.2
- MSVC 14.51.36231
- Release x64
- MPC-BE 1.9.1

## Result

Before the change, the build terminates with C1001 during optimized code
generation.

With WholeProgramOptimization disabled for File_Mpeg4_Elements.cpp, the Release
x64 build completes successfully.

## Exact compiler failure

Observed with:

- Visual Studio 2026 Build Tools 18.8.2
- MSVC 14.51.36231
- Release x64

```text
Generating code
C:\Users\Z\Downloads\MPC-BE-1.9.1\src\ExtLib\MediaInfo\MediaInfo\Multiple\File_Mpeg4_Elements.cpp(1596): fatal error C1001: Internal compiler error. [C:\Users\Z\Downloads\MPC-BE-1.9.1\src\apps\mplayerc\mpc-be.vcxproj]
(compiler file 'D:\a\_work\1\s\src\vctools\Compiler\Utc\src\p2\main.cpp', line 262)

[ERROR] mpc-be.sln Release x64 - Compilation failed
```