### PR TITLE
Fix white area when restoring from tray

### DIFF
--- a/src/apps/mplayerc/MainFrm.cpp
+++ b/src/apps/mplayerc/MainFrm.cpp
@@ -5752,9 +5752,35 @@ LRESULT CMainFrame::OnRestore(WPARAM wParam, LPARAM lParam)
 {
 	if (m_bTrayIcon) {
 		if (!IsWindowVisible()) {
+			// Rebuild the frame/view layout before exposing the hidden window.
+			RecalcLayout();
+
+			// Keep the frame compositor-cloaked on Windows 8+ until its final child
+			// layout and renderer destination have been painted.
+			bool bCloakedForRestore = false;
+			if (SysVersion::IsWin8orLater()) {
+				const BOOL bCloak = TRUE;
+				bCloakedForRestore = SUCCEEDED(DwmSetWindowAttribute(
+					m_hWnd, DWMWA_CLOAK, &bCloak, sizeof(bCloak)));
+			}
+
 			ShowWindow(SW_SHOW);
+
+			// Showing the frame can change the effective client metrics.
+			RecalcLayout();
+			MoveVideoWindow(false, true);
+			RepaintVideo(true);
+			RedrawWindow(nullptr, nullptr,
+				RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+
+			if (bCloakedForRestore) {
+				// Present only the completed frame, never the intermediate restore state.
+				DwmFlush();
+				const BOOL bCloak = FALSE;
+				DwmSetWindowAttribute(m_hWnd, DWMWA_CLOAK, &bCloak, sizeof(bCloak));
+			}
+
 			CreateThumbnailToolbar();
-			MoveVideoWindow();
 			SetForegroundWindow();
 
 			for (const auto& pDockingBar : m_dockingbarsVisible) {


### PR DESCRIPTION
## Summary

Fix a white/unpainted client area that can appear when restoring MPC-BE from the system tray.

## Cause

The tray restore path made the main frame visible before the frame layout, child windows, control bars, and video renderer destination had been fully reconciled.

This allowed DWM to present an intermediate restore state containing stale or unpainted client geometry.

## Fix

* Recalculate the frame layout before exposing the hidden window.
* On Windows 8 and later, temporarily cloak the main HWND during restoration.
* Show the window while it remains compositor-cloaked.
* Recalculate the final visible-client layout.
* Force the video renderer to the resulting destination rectangle.
* Repaint the video and complete the frame/child hierarchy.
* Flush DWM before removing the cloak so only the completed frame is presented.

The normal tray behavior and playback-state restoration are otherwise unchanged.

This change is intentionally limited to `CMainFrame::OnRestore()` and is independent of the fullscreen-transition changes.

## Testing

Tested repeated minimize-to-tray/restore cycles with:

* no media loaded
* audio-only playback
* video playback
* paused video
* windowed state
* maximized state
* repeated tray hide/restore cycles

The player restores directly to the completed layout without exposing the previous white client area.

## Before

https://github.com/user-attachments/assets/f2dcf9dd-0a6c-4eb8-bc26-a9d72b068a29

## After

https://github.com/user-attachments/assets/f1c16d7b-4537-421c-8e8b-a7ea4ac011b7