### PR TITLE
Fix legacy title bar flicker during fullscreen transition when player is empty (follow-up to #1217)

### DIFF
--- a/src/apps/mplayerc/MainFrm.cpp
+++ b/src/apps/mplayerc/MainFrm.cpp
@@ -11257,6 +11257,18 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
 	// presentation point first; unlike a forced RedrawWindow this does not
 	// synchronously repaint a stale pre-WM_SIZE child surface.
 	if (bCloakedForFullscreenTransition) {
+		// Repaint the final frame while still cloaked, before DwmFlush()/uncloak.
+		// Without it, lifting the cloak can flash a one-frame legacy/Basic frame on
+		// some GPU/DWM builds. The comment above warns a forced repaint can paint a
+		// stale pre-WM_SIZE surface; here it is issued after MoveVideoWindow() so the
+		// child geometry is already final and that pitfall does not apply. Only needed
+		// for the empty player (no media), m_eMediaLoadState != MLS_LOADED: a loaded
+		// clip already repaints via its present cadence, so #1217's cloak alone
+		// suffices there.
+		if (m_eMediaLoadState != MLS_LOADED) {
+			RedrawWindow(nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+		}
+
 		DwmFlush();
 
 		const BOOL bCloak = FALSE;


### PR DESCRIPTION
## Summary

This is a targeted follow-up fix for #1217. Following the merge of #1217, entering and exiting fullscreen behaves correctly across all loaded media states (playing, paused, audio-only, and no media loaded). The sole remaining edge case occurs in the **empty player** state (no media loaded): on certain GPU/DWM configurations, a single-frame flash of the legacy/Basic (Windows 7-style) title bar can still be observed during fullscreen transitions.

This patch leaves the `DWMWA_CLOAK` mechanism from #1217 intact and does not alter any code paths for loaded media. It introduces a controlled, forced redraw exclusively for the empty player scenario.

## Investigation

During fullscreen transitions, the top-level window styles (`WS_CAPTION`/`WS_THICKFRAME`) are modified, causing DWM to compose an intermediate non-client (NC) frame. While `DWMWA_CLOAK` suppresses presentation at the DWM level, uncloaking before the final frame is fully painted can leak a single stale frame rendered with the Basic appearance.

When a video stream is loaded, the renderer's own presentation cadence is sufficient to bridge this handoff, making the cloaking mechanism in #1217 effective on its own. An empty player lacks an active video surface to mask this transition, making it the only state where the flash manifests—and on affected hardware, the only state that reproduces the issue.

## Fix

In `CMainFrame::ToggleFullscreen`, immediately before `DwmFlush()` and uncloaking (while the window remains cloaked), trigger a forced full redraw—**only when the player is idle/empty** (`m_eMediaLoadState != MLS_LOADED`):

```cpp
if (m_eMediaLoadState != MLS_LOADED) {
    RedrawWindow(nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW);
}

```

* This call executes **after** `MoveVideoWindow()`, ensuring child window geometry is already in its final layout (forcing a redraw prior to `WM_SIZE` causes stale pre-`WM_SIZE` frames to be painted—the root cause of the previous "cropped video" regression).
* It remains scoped within the existing `IsWin8orLater()` cloaking block; Windows 7 (which lacks cloaking support) is entirely unaffected and behaves identically to #1217.
* Loaded media states avoid this redraw overhead entirely, as the cloaking in #1217 already covers them.

## Why This Approach

* **Minimal footprint and tightly scoped**—adds a single logical branch affecting only the failing code path.

## Testing / Environment

* **Test environments:** Reproducible on Windows 11 26H1 + AMD driver [32.0.12001.2001] and a secondary Windows 10 test machine, but not reproducible on a third Windows 11 machine.
* This is a device/GPU/DWM-dependent race condition that may not manifest across most OS setups, making exact trigger boundaries difficult to isolate—yet it reproduces consistently on affected machines.
* **Before patch:** Flash is visible on affected setups.
* **After patch:** Flash is completely eliminated on the same hardware.
* **Playing / Paused / Audio-only:** Fully covered by #1217; untouched by this change and remains flicker-free.
* **Windows 7 (no cloaking):** Code path unchanged; behavior is identical to #1217.

## Before

https://github.com/user-attachments/assets/719bbe0e-f228-4269-b48f-532549bbfa05

## After

https://github.com/user-attachments/assets/0b9c957f-b31a-4d1b-bd29-11cd5f438c65